### PR TITLE
Fix README to make forking accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
-![luavim](https://raw.githubusercontent.com/elai4/luavim/main/img/screenshot1.png)
-![tree+split](https://raw.githubusercontent.com/elai4/luavim/main/img/screenshot2.png)
+![luavim](/img/screenshot1.png?raw=true)
+![tree+split](/img/screenshot2.png?raw=true)
 
 ## Description
 
@@ -89,7 +89,7 @@ git clone https://github.com/elairavi/luavim.git ~/.config/nvim
 
 - Open neovim with this flag `nvim +checkhealth` you should not see any errors in the output (except for the one related to Python):
 
-![checkhealth](https://raw.githubusercontent.com/elai4/luavim/main/img/checkhealth.png)
+![checkhealth](/img/checkhealth.png?raw=true)
 
 
 * Note: If you're having a problem or some kinda of an error with a plugin, just run these commands:


### PR DESCRIPTION
Hi!

After forking the repo and attempting to update the images for the themes I was using, I noticed that your README hard-coded the full path to the images. Here's a small patch to update the links so they are more compatible with forking!

Thank you for your time!

P.S. This config was an amazing base to start from. Much appreciated!!